### PR TITLE
Update Bungee Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ repositories {
 
 
 dependencies {
-	compileOnly group: 'net.md-5', name: 'bungeecord-api', version: '1.15-SNAPSHOT'
+	compileOnly group: 'net.md-5', name: 'bungeecord-api', version: '1.16-R0.4'
 	compileOnly group: 'org.yaml', name: 'snakeyaml', version: '1.26'
 }
 


### PR DESCRIPTION
Update the bungee dependency so that plugins that run on 1.16 bungee do not get IllegalStateException.